### PR TITLE
initial tests and implementation of globstar routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 node_modules
+coverage/

--- a/README.md
+++ b/README.md
@@ -12,13 +12,15 @@ Often when building a static app, you want to serve multiple routes with the sam
 
 Pathologist is an easy to use [connect](https://github.com/senchalabs/connect) middleware for bringing your single page apps to life. You can define routes with supported [globstar](https://github.com/isaacs/node-glob) matching to serve your static files.
 
+Pathologist simply rewrites the request url to a new static file path. It ___does not___ serve the static file for you, so you will need to use your preferred static server middleware with pathologist. We recommend [alchemist](https://github.com/carrot/alchemist-middleware).
+
 ### Installation
 
 `$ npm install pathologist-middleware --save`
 
 ### Usage
 
-Pathologist accepts an options object which takes globstar-compatible paths as keys and file paths as values. Routes are matched in the order they are defined in the object. Here's an example that serves an admin client on any URLs starting with `/admin`, and serves the user client on all other routes.
+Pathologist accepts an options object which takes globstar-compatible paths as keys and a static file path as values. Routes are matched in the order they are defined in the object. Here's an example that serves an admin client on any URLs starting with `/admin`, and serves the user client on all other routes.
 
 ```javascript
 var http = require('http'),
@@ -27,8 +29,8 @@ var http = require('http'),
 
 var app = connect().use(
   pathologist({
-    '/admin/**/*': 'admin.html',
-    '/**': 'index.html'
+    '/admin/**/*': '/admin.html',
+    '/**': '/index.html'
   })
 );
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Finding the right path since 1967
 
 Often when building a static app, you want to serve multiple routes with the same static file while keeping the URL structure intact for your app's routing logic. Or perhaps you just want to handle multiple routes for a directory of static files.
 
-Pathologist is an easy to use connect middleware for bringing your single page apps to life. You can define routes with supported [globstar](https://github.com/isaacs/node-glob) matching to your static files.
+Pathologist is an easy to use [connect](https://github.com/senchalabs/connect) middleware for bringing your single page apps to life. You can define routes with supported [globstar](https://github.com/isaacs/node-glob) matching to serve your static files.
 
 ### Installation
 
@@ -18,7 +18,7 @@ Pathologist is an easy to use connect middleware for bringing your single page a
 
 ### Usage
 
-Pathologist accepts an options object takes globstar-compatible paths as keys and file paths for values. Routes are matched in the order they are defined in the object. Here's an example that serves an admin client on any URLs starting with `/admin`, and serves the user client on all other routes.
+Pathologist accepts an options object which takes globstar-compatible paths as keys and file paths as values. Routes are matched in the order they are defined in the object. Here's an example that serves an admin client on any URLs starting with `/admin`, and serves the user client on all other routes.
 
 ```javascript
 var http = require('http'),

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -1,4 +1,13 @@
-module.exports = (opts) ->
+minimatch = require 'minimatch'
+send      = require 'send'
+
+module.exports = (base, routes) ->
+  if typeof base isnt 'string'
+    routes  = base
+    base    = process.cwd()
 
   return (req, res, next) ->
-    next(opts)
+    for k, v of routes when minimatch(req.url, k)
+      res.statusCode = 200
+      return send(req, path.resolve(base, v)).pipe(res)
+    next()

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -8,6 +8,6 @@ module.exports = (base, routes) ->
 
   return (req, res, next) ->
     for k, v of routes when minimatch(req.url, k)
-      res.statusCode = 200
-      return send(req, path.resolve(base, v)).pipe(res)
+      req.url = v
+      return next()
     next()

--- a/package.json
+++ b/package.json
@@ -26,5 +26,9 @@
   },
   "engines": {
     "node": ">=0.10.0"
+  },
+  "dependencies": {
+    "send": "^0.3.0",
+    "minimatch": "^0.2.14"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "pathologist",
-  "version": "0.0.0",
+  "name": "pathologist-middleware",
+  "version": "0.0.1",
   "author": "Carrot Creative <dev@carrotcreative.com>",
-  "description": "Middleware for custom routes",
+  "description": "Handling custom static routes since 1967",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "coffeelint": "*",
     "istanbul": "*",
     "mocha-lcov-reporter": "*",
-    "coffee-script": "1.7.x"
+    "coffee-script": "1.7.x",
+    "alchemist-middleware": "0.0.2"
   },
   "scripts": {
     "test": "npm run lint && mocha",

--- a/test/fixtures/basic/admin.html
+++ b/test/fixtures/basic/admin.html
@@ -1,0 +1,1 @@
+<p>hello world from admin!</p>

--- a/test/fixtures/basic/index.html
+++ b/test/fixtures/basic/index.html
@@ -1,1 +1,1 @@
-<p>hello world!</p>
+<p>hello world from index!</p>

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -5,10 +5,23 @@ describe 'basic', ->
   it 'should be registered as middleware', ->
     (-> connect().use(pathologist())).should.not.throw()
 
-  it 'should modify a request body', (done) ->
-    app = connect().use(pathologist("middleware'd!"))
+describe 'routing', ->
+  before ->
+    @app = connect().use(
+      pathologist(path.join(base_path, 'basic'),
+        '/admin/**':  'admin.html',
+        '/**':        'index.html'
+      )
+    )
 
-    chai.request(app).get('/').res (res) ->
-      res.should.have.status(500)
-      res.text.should.equal("middleware'd!")
+  it 'should match on the namespaced admin route', (done) ->
+    chai.request(@app).get('/admin/dashboard').res (res) ->
+      res.should.have.status(200)
+      res.text.should.equal('<p>hello world from admin!</p>\n')
+      done()
+
+  it 'should match on the full globstar route', (done) ->
+    chai.request(@app).get('/dashboard').res (res) ->
+      res.should.have.status(200)
+      res.text.should.equal('<p>hello world from index!</p>\n')
       done()

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -10,7 +10,7 @@ describe 'routing', ->
     @app = connect().use(
       pathologist(path.join(base_path, 'basic'),
         '/admin/**':  'admin.html',
-        '**':        'index.html'
+        '**':         'index.html'
       )
     )
 

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -10,7 +10,7 @@ describe 'routing', ->
     @app = connect().use(
       pathologist(path.join(base_path, 'basic'),
         '/admin/**':  'admin.html',
-        '/**':        'index.html'
+        '**':        'index.html'
       )
     )
 
@@ -18,6 +18,12 @@ describe 'routing', ->
     chai.request(@app).get('/admin/dashboard').res (res) ->
       res.should.have.status(200)
       res.text.should.equal('<p>hello world from admin!</p>\n')
+      done()
+
+  it 'should match all other routes due to ** globstar', (done) ->
+    chai.request(@app).get('/fizz/buzz').res (res) ->
+      res.should.have.status(200)
+      res.text.should.equal('<p>hello world from index!</p>\n')
       done()
 
   it 'should match on the full globstar route', (done) ->

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -1,4 +1,5 @@
-connect = require 'connect'
+connect   = require 'connect'
+alchemist = require 'alchemist-middleware'
 
 describe 'basic', ->
 
@@ -7,12 +8,15 @@ describe 'basic', ->
 
 describe 'routing', ->
   before ->
-    @app = connect().use(
-      pathologist(path.join(base_path, 'basic'),
-        '/admin/**':  'admin.html',
-        '**':         'index.html'
+    @app = connect()
+      .use(
+        pathologist(path.join(base_path, 'basic'),
+          '/admin/**':  '/admin.html',
+          '**':         '/index.html'
+        )
+      ).use(
+        alchemist(path.join(base_path, 'basic'))
       )
-    )
 
   it 'should match on the namespaced admin route', (done) ->
     chai.request(@app).get('/admin/dashboard').res (res) ->

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -7,31 +7,44 @@ describe 'basic', ->
     (-> connect().use(pathologist())).should.not.throw()
 
 describe 'routing', ->
-  before ->
-    @app = connect()
-      .use(
-        pathologist(path.join(base_path, 'basic'),
-          '/admin/**':  '/admin.html',
-          '**':         '/index.html'
-        )
-      ).use(
-        alchemist(path.join(base_path, 'basic'))
-      )
+  describe 'route match', ->
+    before ->
+      @app = connect()
+        .use(
+          pathologist(path.join(base_path, 'basic'),
+            '/admin/**':  '/admin.html',
+            '**':         '/index.html'
+          )
+        ).use(alchemist(path.join(base_path, 'basic')))
 
-  it 'should match on the namespaced admin route', (done) ->
-    chai.request(@app).get('/admin/dashboard').res (res) ->
-      res.should.have.status(200)
-      res.text.should.equal('<p>hello world from admin!</p>\n')
-      done()
+    it 'should match on the namespaced admin route', (done) ->
+      chai.request(@app).get('/admin/dashboard').res (res) ->
+        res.should.have.status(200)
+        res.text.should.equal('<p>hello world from admin!</p>\n')
+        done()
 
-  it 'should match all other routes due to ** globstar', (done) ->
-    chai.request(@app).get('/fizz/buzz').res (res) ->
-      res.should.have.status(200)
-      res.text.should.equal('<p>hello world from index!</p>\n')
-      done()
+    it 'should match all other routes due to ** globstar', (done) ->
+      chai.request(@app).get('/fizz/buzz').res (res) ->
+        res.should.have.status(200)
+        res.text.should.equal('<p>hello world from index!</p>\n')
+        done()
 
-  it 'should match on the full globstar route', (done) ->
-    chai.request(@app).get('/dashboard').res (res) ->
-      res.should.have.status(200)
-      res.text.should.equal('<p>hello world from index!</p>\n')
-      done()
+    it 'should match on the full globstar route', (done) ->
+      chai.request(@app).get('/dashboard').res (res) ->
+        res.should.have.status(200)
+        res.text.should.equal('<p>hello world from index!</p>\n')
+        done()
+
+  describe 'no match', ->
+    it 'should pass it to the next middleware unmodified', ->
+      app = connect()
+        .use(
+          pathologist(path.join(base_path, 'basic'),
+            '/admin/**':  '/admin.html'
+          )
+        ).use(alchemist(path.join(base_path, 'basic')))
+
+      chai.request(app).get('/index.html').res (res) ->
+        res.should.have.status(200)
+        res.text.should.equal('<p>hello world from index!</p>\n')
+        done()


### PR DESCRIPTION
Serves globstar matched routes with a single static file.

``` coffee
app.use(
  pathologist
    '/admin/**': 'admin.html',
    '/**': 'index.html'
)
```

You can pass in a base directory path as the first argument to pathologist, otherwise it'll look in `process.cwd()` for the file.
